### PR TITLE
fix: correct occured->occurred typo in error log message

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -31,7 +31,7 @@ server_state_check_timer = function(premature)
         if ret then
             log(DEBUG, "server state check over")
         else
-            log(ERR, "error occured when check server state:", result)
+            log(ERR, "error occurred when check server state:", result)
         end
         new_timer(server_state_check_interval, server_state_check_timer)
     end


### PR DESCRIPTION
Fix typo in src/init.lua line 34: `error occured` → `error occurred` in server state check error log.

User-visible error log message.

Gate-1✅ (no existing PR for this fix) | Gate-2✅ (0 OPEN PRs) | Gate-3✅ (1 commit)